### PR TITLE
Added dynamic LDAP configuration feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,35 @@ It will also mix in the following defaults, which should be customized.
 ### LDAP Verifier class
 
 The `Verifier` class has a `verify` function that is the passport verify callback. In this module it gets called after LDAP authentication succeeds. By default it does nothing but you can overwrite it to make furthers validation
-checks. See [examples/app.js](examples/app.js#L56). 
+checks. See [examples/app.js](examples/app.js#L56).
+
+
+### Asynchronous LDAP Strategy configuration
+
+The `getLDAPConfiguration` option can be included in the `server` settings to define an asynchronous function that dynamically adjusts the LDAP server settings. This makes it possible to take advantage of the passport LDAP authentication module's option for dynamic configuration in place of a static configuration for the LDAP Strategy.
+
+The server options returned in a callback by the `getLDAPConfiguration` function will override the default and static settings prior to the LDAP bind step.
+
+I.E. The credentials passed in an authentication request can be used as the bind credentials in an Active Directory setup that does not include common bind credentials...
+
+```javascript
+app.configure(authentication(config))
+.configure(jwt())
+.configure(local())
+.configure(ldap({
+  // asynchronous function used to pass alternate LDAP settings
+  getLDAPConfiguration: function(req, callback) {
+    var opts = {
+      server: {
+        bindDn: req.body.username,
+        bindCredentials: req.body.password
+      }
+    };
+    callback(null, opts);
+  }
+}));
+```
+
 
 ### Usage with `feathers-authentication-jwt`
 
@@ -57,11 +85,11 @@ To authenticate following requests using the jwt use `feathers-authentication-jw
 
 To get rid of this dependency and store necessary data in the JWT payload see
 [examples/app.js](examples/app.js#L47) and [examples/app.js](examples/app.js#L79).
- 
+
 
 ## Simple Example
 
-Here's an example of a Feathers server that uses `feathers-authentication-ldap`. 
+Here's an example of a Feathers server that uses `feathers-authentication-ldap`.
 
 ```js
 const feathers = require('feathers');

--- a/README.md
+++ b/README.md
@@ -54,27 +54,26 @@ checks. See [examples/app.js](examples/app.js#L56).
 
 ### Asynchronous LDAP Strategy configuration
 
-The `getLDAPConfiguration` option can be included in the `server` settings to define an asynchronous function that dynamically adjusts the LDAP server settings. This makes it possible to take advantage of the passport LDAP authentication module's option for dynamic configuration in place of a static configuration for the LDAP Strategy.
+Per request configuration of the LDAP strategy is supported by taking advantage of
+the passport-ldapauth [asynchronous configuration retrieval](https://github.com/vesse/passport-ldapauth#asynchronous-configuration-retrieval)
+feature.
 
-The server options returned in a callback by the `getLDAPConfiguration` function will override the default and static settings prior to the LDAP bind step.
+In place of the options a function can be passed when initializing the feathers-authentication-ldap
+module. This function will be called with the authentication request object and it should
+return a promise that resolves the altered options. These altered options will be merged with
+the default and static settings.
 
-I.E. The credentials passed in an authentication request can be used as the bind credentials in an Active Directory setup that does not include common bind credentials...
+I.E. The credentials passed in an authentication request can be used as the bind credentials
+in an Active Directory setup that does not include common bind credentials...
 
 ```javascript
 app.configure(authentication(config))
 .configure(jwt())
 .configure(local())
-.configure(ldap({
-  // asynchronous function used to pass alternate LDAP settings
-  getLDAPConfiguration: function(req, callback) {
-    var opts = {
-      server: {
-        bindDn: req.body.username,
-        bindCredentials: req.body.password
-      }
-    };
-    callback(null, opts);
-  }
+.configure(ldap( function (req) {
+  return new Promise(function (resolve, reject) {
+    resolve({ server: { bindDn: req.body.username, bindCredentials: req.body.password } });
+  });
 }));
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,18 @@ export default function init (options = {}) {
     let name = options.name || defaults.name;
     let authOptions = app.get('auth') || {};
     let ldapOptions = authOptions[name] || {};
-    const ldapSettings = merge({}, defaults, ldapOptions, omit(options, ['Verifier']));
+    const ldapSettings = merge({}, defaults, ldapOptions, omit(options, ['Verifier', 'getLDAPConfiguration']));
     const Verifier = options.Verifier || DefaultVerifier;
+    let getLDAPConfiguration = function(req, callback) {
+      if (options.getLDAPConfiguration) {
+        options.getLDAPConfiguration(req, function (err, xo) {
+          callback(null, merge(ldapSettings, xo));
+        });
+      }
+      else {
+        callback(null, ldapSettings);
+      }
+    };
 
     // plugin setup: register strategy in feathers passport
     app.setup = function () {
@@ -55,7 +65,7 @@ export default function init (options = {}) {
 
       // Register 'ldap' strategy with passport
       debug('Registering ldap authentication strategy with options:', ldapSettings);
-      app.passport.use(ldapSettings.name, new LdapStrategy(ldapSettings, verifier.verify.bind(verifier)));
+      app.passport.use(ldapSettings.name, new LdapStrategy(getLDAPConfiguration, verifier.verify.bind(verifier)));
       app.passport.options(ldapSettings.name, ldapSettings); // do we need this ??
 
       return result;

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default function init (options = {}) {
     }
 
     // Construct ldapSettings for passport ldap strategy
-    let name = options.name || defaults.name;
+    let name = (typeof(options) !== 'function' && options.name) || defaults.name;
     let authOptions = app.get('auth') || {};
     let ldapOptions = authOptions[name] || {};
     const ldapSettings = merge({}, defaults, ldapOptions, (typeof options === 'function' ? {} : omit(options, ['Verifier'])));


### PR DESCRIPTION
I required the ability to dynamically adjust LDAP settings based on the authentication request and passport-ldapauth provides the option to pass a configuration function in place of a static configuration option, but the feathers-authentication-ldap package only supported static configuration.

This pull request adds a server configuration option that can be used to define an asynchronous method for LDAP settings that will override any default or static settings.